### PR TITLE
add naive implementation of conversion to plain text

### DIFF
--- a/pkg/modules/libreoffice/api/api.go
+++ b/pkg/modules/libreoffice/api/api.go
@@ -150,6 +150,11 @@ type Options struct {
 	// PdfFormats allows to convert the resulting PDF to PDF/A-1b, PDF/A-2b,
 	// PDF/A-3b and PDF/UA.
 	PdfFormats gotenberg.PdfFormats
+
+	// Set output format for conversion.
+	// Extends route to also export to plain text and html.
+	// TODO: make a struct of strings as PdfFormats...
+	OutputFormat string
 }
 
 // DefaultOptions returns the default values for Options.
@@ -182,6 +187,7 @@ func DefaultOptions() Options {
 			PdfA:  "",
 			PdfUa: false,
 		},
+		OutputFormat: "pdf",
 	}
 }
 

--- a/pkg/modules/libreoffice/api/libreoffice.go
+++ b/pkg/modules/libreoffice/api/libreoffice.go
@@ -254,7 +254,7 @@ func (p *libreOfficeProcess) pdf(ctx context.Context, logger *zap.Logger, inputP
 	args := []string{
 		"--no-launch",
 		"--format",
-		"pdf",
+		options.OutputFormat,
 	}
 
 	args = append(args, "--port", fmt.Sprintf("%d", p.socketPort))


### PR DESCRIPTION
Simple modification to allow conversion of rtf to text.

Just add outputFormat=text as a form field:
```
curl -s -X POST http://localhost:3002/forms/libreoffice/convert -F "files=@test.rtf"  -F "outputFormat=text" -o test.rtf.txt
```

Caveats:
- If multiple files are converted in bulk the file suffixes are still .pdf in the resulting zip archive. (Should be easy to fix,)
- Will probably conflic with other options.
- A little bit awkward to just add this to the PDF conversion code. But  building a new route for libreOffice would probably have required a big refactoring to minimize duplicated code.
- No support for html conversion. This would be more complex as one have to collect a folder of resource files in advanced cases. 